### PR TITLE
[FEAT] Removing amp=false from SE3benchmarks

### DIFF
--- a/DGLPyTorch/DrugDiscovery/SE3Transformer/run_dgl_benchmarks.sh
+++ b/DGLPyTorch/DrugDiscovery/SE3Transformer/run_dgl_benchmarks.sh
@@ -17,15 +17,10 @@ echo "DGL version: $(python -c "import dgl; print(dgl.__version__)")" | tee -a $
 
 # Run benchmarks
 export DGLBACKEND=pytorch
-bash scripts/benchmark_train.sh 120 false 2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train.sh 240 false 2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train.sh 120 true  2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train.sh 240 true  2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train_multi_gpu.sh 120 false 2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train_multi_gpu.sh 240 false 2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train_multi_gpu.sh 120 true  2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_train_multi_gpu.sh 240 true  2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_inference.sh 400 false 2>&1 | tee -a $LOGFILE
-bash scripts/benchmark_inference.sh 400 true  2>&1 | tee -a $LOGFILE
+bash scripts/benchmark_train.sh 120 2>&1 | tee -a $LOGFILE
+bash scripts/benchmark_train.sh 240 2>&1 | tee -a $LOGFILE
+bash scripts/benchmark_train_multi_gpu.sh 120 2>&1 | tee -a $LOGFILE
+bash scripts/benchmark_train_multi_gpu.sh 240 2>&1 | tee -a $LOGFILE
+bash scripts/benchmark_inference.sh 400 2>&1 | tee -a $LOGFILE
 
 echo "Benchmarks completed. Results saved to $LOGFILE"  


### PR DESCRIPTION
## Motivation

Turning amp=false usually gave similar results to amp=true and didn't add much to the story of these benchmarks so we're removing it.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
